### PR TITLE
gem の rails-erd を導入しER 図を出力

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ yarn-debug.log*
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+erd.pdf

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development do
   gem "web-console", ">= 3.3.0"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "annotate"
+  gem "rails-erd"
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     byebug (11.1.3)
     case_transform (0.2)
       activesupport
+    choice (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
@@ -163,6 +164,11 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
+    rails-erd (1.7.2)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     railties (6.0.6)
@@ -216,6 +222,8 @@ GEM
       rubocop (>= 1.33.0, < 2.0)
     rubocop-rspec (2.13.2)
       rubocop (~> 1.33)
+    ruby-graphviz (1.2.5)
+      rexml
     ruby-progressbar (1.11.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -286,6 +294,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.7)
+  rails-erd
   rspec-rails
   rubocop-rails
   rubocop-rspec

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: articles
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  title      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_articles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class Article < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy

--- a/app/models/article_like.rb
+++ b/app/models/article_like.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: article_likes
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_article_likes_on_article_id  (article_id)
+#  index_article_likes_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class ArticleLike < ApplicationRecord
   belongs_to :user
   belongs_to :article

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_article_id  (article_id)
+#  index_comments_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :article

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,29 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  allow_password_change  :boolean          default(FALSE)
+#  email                  :string
+#  encrypted_password     :string           default(""), not null
+#  name                   :string
+#  provider               :string           default("email"), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  tokens                 :json
+#  uid                    :string           default(""), not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,41 @@
+# == Route Map
+#
+#                                Prefix Verb   URI Pattern                                                                              Controller#Action
+#                      new_user_session GET    /auth/sign_in(.:format)                                                                  devise_token_auth/sessions#new
+#                          user_session POST   /auth/sign_in(.:format)                                                                  devise_token_auth/sessions#create
+#                  destroy_user_session DELETE /auth/sign_out(.:format)                                                                 devise_token_auth/sessions#destroy
+#                     new_user_password GET    /auth/password/new(.:format)                                                             devise_token_auth/passwords#new
+#                    edit_user_password GET    /auth/password/edit(.:format)                                                            devise_token_auth/passwords#edit
+#                         user_password PATCH  /auth/password(.:format)                                                                 devise_token_auth/passwords#update
+#                                       PUT    /auth/password(.:format)                                                                 devise_token_auth/passwords#update
+#                                       POST   /auth/password(.:format)                                                                 devise_token_auth/passwords#create
+#              cancel_user_registration GET    /auth/cancel(.:format)                                                                   devise_token_auth/registrations#cancel
+#                 new_user_registration GET    /auth/sign_up(.:format)                                                                  devise_token_auth/registrations#new
+#                edit_user_registration GET    /auth/edit(.:format)                                                                     devise_token_auth/registrations#edit
+#                     user_registration PATCH  /auth(.:format)                                                                          devise_token_auth/registrations#update
+#                                       PUT    /auth(.:format)                                                                          devise_token_auth/registrations#update
+#                                       DELETE /auth(.:format)                                                                          devise_token_auth/registrations#destroy
+#                                       POST   /auth(.:format)                                                                          devise_token_auth/registrations#create
+#                   auth_validate_token GET    /auth/validate_token(.:format)                                                           devise_token_auth/token_validations#validate_token
+#         rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                  action_mailbox/ingresses/postmark/inbound_emails#create
+#            rails_relay_inbound_emails POST   /rails/action_mailbox/relay/inbound_emails(.:format)                                     action_mailbox/ingresses/relay/inbound_emails#create
+#         rails_sendgrid_inbound_emails POST   /rails/action_mailbox/sendgrid/inbound_emails(.:format)                                  action_mailbox/ingresses/sendgrid/inbound_emails#create
+#   rails_mandrill_inbound_health_check GET    /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#health_check
+#         rails_mandrill_inbound_emails POST   /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#create
+#          rails_mailgun_inbound_emails POST   /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)                              action_mailbox/ingresses/mailgun/inbound_emails#create
+#        rails_conductor_inbound_emails GET    /rails/conductor/action_mailbox/inbound_emails(.:format)                                 rails/conductor/action_mailbox/inbound_emails#index
+#                                       POST   /rails/conductor/action_mailbox/inbound_emails(.:format)                                 rails/conductor/action_mailbox/inbound_emails#create
+#         rails_conductor_inbound_email GET    /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#show
+#                                       PATCH  /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#update
+#                                       PUT    /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#update
+#                                       DELETE /rails/conductor/action_mailbox/inbound_emails/:id(.:format)                             rails/conductor/action_mailbox/inbound_emails#destroy
+# rails_conductor_inbound_email_reroute POST   /rails/conductor/action_mailbox/:inbound_email_id/reroute(.:format)                      rails/conductor/action_mailbox/reroutes#create
+#                    rails_service_blob GET    /rails/active_storage/blobs/:signed_id/*filename(.:format)                               active_storage/blobs#show
+#             rails_blob_representation GET    /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format) active_storage/representations#show
+#                    rails_disk_service GET    /rails/active_storage/disk/:encoded_key/*filename(.:format)                              active_storage/disk#show
+#             update_rails_disk_service PUT    /rails/active_storage/disk/:encoded_token(.:format)                                      active_storage/disk#update
+#                  rails_direct_uploads POST   /rails/active_storage/direct_uploads(.:format)                                           active_storage/direct_uploads#create
+
 Rails.application.routes.draw do
   mount_devise_token_auth_for "User", at: "auth"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/config/rubocop/rubocop.yml
+++ b/config/rubocop/rubocop.yml
@@ -133,7 +133,7 @@ Metrics/CyclomaticComplexity:
 # * 禁止 160文字
 # のイメージ
 Metrics/LineLength:
-  Max: 160
+  Max: 200  #元160
   Exclude:
     - "db/migrate/*.rb"
 

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require "annotate"
+  task set_annotation_options: :environment do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      "active_admin" => "false",
+      "additional_file_patterns" => [],
+      "routes" => "false",
+      "models" => "true",
+      "position_in_routes" => "before",
+      "position_in_class" => "before",
+      "position_in_test" => "before",
+      "position_in_fixture" => "before",
+      "position_in_factory" => "before",
+      "position_in_serializer" => "before",
+      "show_foreign_keys" => "true",
+      "show_complete_foreign_keys" => "false",
+      "show_indexes" => "true",
+      "simple_indexes" => "false",
+      "model_dir" => "app/models",
+      "root_dir" => "",
+      "include_version" => "false",
+      "require" => "",
+      "exclude_tests" => "false",
+      "exclude_fixtures" => "false",
+      "exclude_factories" => "false",
+      "exclude_serializers" => "false",
+      "exclude_scaffolds" => "true",
+      "exclude_controllers" => "true",
+      "exclude_helpers" => "true",
+      "exclude_sti_subclasses" => "false",
+      "ignore_model_sub_dir" => "false",
+      "ignore_columns" => nil,
+      "ignore_routes" => nil,
+      "ignore_unknown_models" => "false",
+      "hide_limit_column_types" => "integer,bigint,boolean",
+      "hide_default_column_types" => "json,jsonb,hstore",
+      "skip_on_db_migrate" => "false",
+      "format_bare" => "true",
+      "format_rdoc" => "false",
+      "format_yard" => "false",
+      "format_markdown" => "false",
+      "sort" => "false",
+      "force" => "false",
+      "frozen" => "false",
+      "classified_sort" => "true",
+      "trace" => "false",
+      "wrapper_open" => nil,
+      "wrapper_close" => nil,
+      "with_comment" => "true",
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: article_likes
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_article_likes_on_article_id  (article_id)
+#  index_article_likes_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :article_like do
     user { nil }

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: articles
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  title      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_articles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :article do
     title { "MyString" }

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_article_id  (article_id)
+#  index_comments_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :comment do
     body { "MyText" }

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: article_likes
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_article_likes_on_article_id  (article_id)
+#  index_article_likes_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
 require "rails_helper"
 
 RSpec.describe ArticleLike, type: :model do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: articles
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  title      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_articles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 require "rails_helper"
 
 RSpec.describe Article, type: :model do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_article_id  (article_id)
+#  index_comments_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
 require "rails_helper"
 
 RSpec.describe Comment, type: :model do


### PR DESCRIPTION
##概要

- gem の `rails-erd` を導入し、ER 図を出力しました。
- 作成後ER 図（erd.pdf）は Git の監視下から外しました。
- annotate を走らせ、各ファイル内にスキーマ情報を表示しました。
- rubocopのエラー解消のためにrubocop.ymlの書き換えをしました。