### PR TITLE
既存 API の修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class ArticlesController < BaseApiController
-      # before_action :current_user
+      before_action :authenticate_user!, only: [:create, :update, :destroy]
 
       def index
         articles = Article.all.order(updated_at: :desc)

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,7 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
-  def current_user
-    @current_user ||= User.first
-    # ||の左側がtrueだったら右側は実行しない(if => false)
-    # ||の左側がfalse/nilだったら右側を実行する（if => true）
-  end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -79,3 +79,8 @@ RSpec/ScatteredSetup:
 RSpec/AnyInstance:
   Exclude:
     - "spec/requests/api/v1/*.rb"
+
+# letオーバーはご愛嬌
+RSpec/MultipleMemoizedHelpers:
+  Exclude:
+    - "spec/requests/api/v1/*.rb"

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -50,23 +50,22 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "POST /articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
+
     # binding.pry
+    let(:headers) { current_user.create_new_auth_token }
+    let(:current_user) { create(:user) } # ここで急に出てきてもわからないから次でこのcurrent_userを定義する
 
     context "適切なパラメーターを送信したとき" do
       let(:params) do
         { article: FactoryBot.attributes_for(:article) }
       end
-      # binding.pry
-      let(:current_user) { create(:user) } # ここで急に出てきてもわからないから次でこのcurrent_userを定義する
-      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
 
       it "記事のデータが作成できる" do
         # binding.pry
         # subject  #ここにsubjectがあるとchangeで変化を見られないからコメントアウト
         # binding.pry
         expect { subject }.to change { Article.count }.by(1) # サブジェクトにどんな変化があったのか⇨article数が一つ増える
-        # binding.pry
         res = JSON.parse(response.body)
         expect(res["title"]).to eq params[:article][:title] # 上で送った値と、resとして返ってきている値が等しい
         expect(res["body"]).to eq params[:article][:body]
@@ -87,12 +86,10 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "PATCH /articles/:id" do
-    subject { patch(api_v1_article_path(article_id), params: params) }
-
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    subject { patch(api_v1_article_path(article_id), params: params, headers: headers) }
 
     let(:current_user) { create(:user) }
-
+    let(:headers) { current_user.create_new_auth_token }
     context "ログインユーザーが自身の投稿を更新しようとした時" do
       let(:article_id) { article.id }
       let(:article) { create(:article, user: current_user) }
@@ -129,11 +126,10 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /articles/:id" do
-    subject { delete(api_v1_article_path(article_id)) }
-
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    subject { delete(api_v1_article_path(article_id), headers: headers) }
 
     let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "ログインユーザーが自身の投稿を削除しようとした時" do
       let(:article_id) { article.id }


### PR DESCRIPTION
##概要

- `devise_token_auth`で提供されるヘルパーメソッドを使用可能にしました。
- ヘルパーメソッドで認証に制限を与えました。
- rubocopのルールを変更しました。