### PR TITLE
下書き記事の一覧/詳細 のAPI実装

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module V1
+    class Articles::DraftsController < BaseApiController
+      before_action :authenticate_user!
+
+      def index
+        articles = current_user.articles.draft.order(updated_at: :desc)
+        # articles = Article.all.order(updated_at: :desc)
+        # articles = articles.where(status: "draft")
+        render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+      end
+
+      def show
+        article = current_user.articles.draft.find(params[:id])
+        render json: article, serializer: Api::V1::ArticleSerializer
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -4,23 +4,19 @@ module Api
       before_action :authenticate_user!, only: [:create, :update, :destroy]
 
       def index
-        articles = Article.all.order(updated_at: :desc)
-        articles = articles.where(status: "published")
+        articles = Article.published.order(updated_at: :desc)
+        # articles = Article.all.order(updated_at: :desc)
+        # articles = articles.where(status: "published")
         render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
       end
 
       def show
-        article = Article.find(params[:id])
-        if article.published?
-          render json: article, serializer: Api::V1::ArticleSerializer # 出力するデータが配列ではない場合はeach_serializerではなく、serializerを設定
-        end
+        article = Article.published.find(params[:id])
+        render json: article, serializer: Api::V1::ArticleSerializer # 出力するデータが配列ではない場合はeach_serializerではなく、serializerを設定
       end
 
       def create
-        # binding.pry
-        # article = current_user.articles.new(article_params)
         article = Article.new(article_params)
-        # binding.pry
         article.save!
         render json: article, serializer: Api::V1::ArticleSerializer
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+      namespace :articles do
+        resources :drafts, only: [:index, :show]
+      end
       resources :articles
     end
   end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -68,12 +68,14 @@ RSpec/MultipleExpectations:
     - "spec/requests/*.rb"
     - "spec/requests/api/v1/*.rb"
     - "spec/requests/api/v1/auth/*.rb"
+    - "spec/requests/api/v1/articles/*.rb"
 
 # 同じこともたまには書きたいやん
 RSpec/ScatteredSetup:
   Exclude:
     - "spec/requests/*.rb"
     - "spec/requests/api/v1/*.rb"
+    - "spec/requests/api/v1/articles/*.rb"
 
 #一旦無視しよとのこと
 RSpec/AnyInstance:

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  describe "GET /api/v1/articles/drafts" do
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+    before { create(:article, status: "published", title: 0, updated_at: 4.days.ago, user: current_user) }
+    before { create(:article, status: "draft", title: 1, updated_at: 3.days.ago, user: current_user) }
+    before { create(:article, status: "draft", title: 2, updated_at: 2.days.ago, user: current_user) }
+    before { create(:article, status: "draft", title: 3, updated_at: 1.days.ago, user: current_user) }
+
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    it "下書き用の記事の一覧を取得できる" do
+      subject
+      expect(response).to have_http_status(:success) # 正常に通信できているか？
+      res = JSON.parse(response.body) # 一覧として帰ってきているデータ数が、beforeで作成したデータ数と一致するか？
+      expect(res.length).to eq 3
+      expect(res[0].keys).to eq ["id", "title", "created_at", "updated_at", "status", "user"] # 一覧として帰ってきているデータの構成が、beforeで作成したデータと一致するか？
+      expect(res[0]["user"].keys).to eq ["id", "name", "email", "password"] # 一覧として帰ってきているデータのうち関連データとして存在するuserがちゃんとできていて、beforeで作成したデータと一致するか？
+      expect(res[0]["title"]).to eq "3" # コントローラのdesc→ascに書き換えたときにresに入る値の順番が入れ替わったので,その時点で表示の順番が入れ替わっている証拠になる
+      expect(res[0]["status"]).to eq "draft" # 下書き用のみ表示されているか
+      expect(res[0]["status"]).not_to eq "published" # 公開用は表示されないか
+    end
+  end
+
+  describe "GET /api/v1/articles/drafts/:id" do
+    subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    context "指定したidの下書き用記事データが存在するとき" do
+      let(:article_id) { article.id } # ここで急に出てきてもわからないから次でこのuser.idを定義する
+      let(:article) { create(:article, user: current_user, status: "draft") } # これでuser.idが何かわかるようになる
+
+      it "その記事のレコードが取得できる" do
+        # binding.pry
+        subject
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq article.title
+        expect(res["body"]).to eq article.body
+        expect(res["id"]).to eq article.id
+        expect(res["status"]).to eq article.status
+        expect(response).to have_http_status(:ok)
+        expect(res["user"]["id"]).to eq article.user.id
+        expect(res["user"].keys).to eq ["id", "name", "email", "password"]
+      end
+    end
+
+    context "指定したidの記事のデータが存在しないとき" do
+      let(:article_id) { 1_000_000 } # 存在しないものを書くので仮にFactryBotでつくられていたとしてもなかなか被ることがない数字を指定
+      it "記事が見つからない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound) # raiseなのに注意！　データが見つからないこと（＝エラーとなること）を期待している
+      end
+    end
+
+    context "指定したidが他人の下書き用記事データだったとき" do
+      let(:article_id) { article.id }
+      let!(:article) { create(:article, user: other_user, status: "draft") }
+      let(:other_user) { create(:user) }
+
+      it "記事が見つからない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound) # raiseなのに注意！　データが見つからないこと（＝エラーとなること）を期待している
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       let(:article) { create(:article) } # これでuser.idが何かわかるようになる
 
       it "記事が見つからない" do
-        expect { subject }.to raise_error(ActionController::MissingExactTemplate) # raiseなのに注意！　データが見つからないこと（＝エラーとなること）を期待している
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound) # raiseなのに注意！　データが見つからないこと（＝エラーとなること）を期待している
       end
     end
   end


### PR DESCRIPTION
##　概要

- 新たにendpointを追加し、下書き記事専用のコントローラーを作成しました。
- 下書き記事の一覧/詳細 のAPI実装テストを作成しました。
- rubocopのルールに変更を加えました。
- エラー内容が任意となるように変更を加えました。