### PR TITLE
マイページでの記事一覧表示のAPI実装

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    class Current::ArticlesController < BaseApiController
+      before_action :authenticate_user!
+      def index
+        articles = current_user.articles.published.order(updated_at: :desc)
+        render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "articles/index"
   root to: "home#index"
 
   # reload 対策
@@ -14,6 +15,10 @@ Rails.application.routes.draw do
       }
       namespace :articles do
         resources :drafts, only: [:index, :show]
+      end
+
+      namespace :current do
+        resources :articles, only: [:index]
       end
       resources :articles
     end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -69,6 +69,7 @@ RSpec/MultipleExpectations:
     - "spec/requests/api/v1/*.rb"
     - "spec/requests/api/v1/auth/*.rb"
     - "spec/requests/api/v1/articles/*.rb"
+    - "spec/requests/api/v1/current/*.rb"
 
 # 同じこともたまには書きたいやん
 RSpec/ScatteredSetup:
@@ -76,6 +77,7 @@ RSpec/ScatteredSetup:
     - "spec/requests/*.rb"
     - "spec/requests/api/v1/*.rb"
     - "spec/requests/api/v1/articles/*.rb"
+    - "spec/requests/api/v1/current/*.rb"
 
 #一旦無視しよとのこと
 RSpec/AnyInstance:

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Current::Articles", type: :request do
+  describe "GET /api/v1/current/articles" do
+    subject { get(api_v1_current_articles_path, headers: headers) }
+
+    before { create(:article, title: 0, updated_at: 4.days.ago) }
+    before { create(:article, status: "published", title: 1, updated_at: 3.days.ago, user: current_user) }
+    before { create(:article, status: "published", title: 2, updated_at: 2.days.ago, user: current_user) }
+    before { create(:article, status: "published", title: 3, updated_at: 1.days.ago, user: current_user) }
+
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    it "ログインユーザーの公開用の記事の一覧を取得できる" do
+      subject
+      expect(response).to have_http_status(:success)
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
+      expect(res[0].keys).to eq ["id", "title", "created_at", "updated_at", "status", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email", "password"]
+      expect(res[0]["title"]).to eq "3"
+      expect(res[0]["status"]).to eq "published"  # 　公開用のみ表示
+      expect(res[0]["user"]["id"]).to eq current_user.id  # 　投稿はログインユーザーのもののみ
+    end
+  end
+end


### PR DESCRIPTION
##概要

- マイページでログインユーザーの記事一覧表示のAPIを実装しました。
- それに伴ったrubocopのルール変更を行いました。